### PR TITLE
Use InvariantCulture instead of en-US

### DIFF
--- a/Source/Assets.cs
+++ b/Source/Assets.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -36,7 +35,6 @@ public static class Assets
 
 	public record struct DialogLine(string Face, string Text, string Voice);
 
-	public static readonly CultureInfo Culture = new CultureInfo("en-US");
 	public static readonly Dictionary<string, Map> Maps = new(StringComparer.OrdinalIgnoreCase);
 	public static readonly Dictionary<string, Shader> Shaders = new(StringComparer.OrdinalIgnoreCase);
 	public static readonly Dictionary<string, Texture> Textures = new(StringComparer.OrdinalIgnoreCase);

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -15,8 +15,10 @@ class Program
 			HandleError((Exception)e.ExceptionObject);
 		};
 
-		Thread.CurrentThread.CurrentCulture = Assets.Culture;
-		Thread.CurrentThread.CurrentUICulture = Assets.Culture;
+		Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+		Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+		CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+		CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
 
 		try
 		{


### PR DESCRIPTION
[Someone in Celestecord](https://discord.com/channels/403698615446536203/666197738026827786/1201928848900636723) had a float parsing crash with `The input string '.5' was not in a correct format.` (despite their PC being set to en-US and the code also setting that culture). This change fixed it for them. (No, just adding the DefaultThreadCurrentCulture assignments with en-US did not. Not sure about just changing the existing lines to InvariantCulture without adding the defaults, I didn't want to keep spamming them with zips after making a version that works.)