### PR TITLE
Always check uniforms before setting them

### DIFF
--- a/Source/Actors/Badeline.cs
+++ b/Source/Actors/Badeline.cs
@@ -19,7 +19,7 @@ public class Badeline : NPC
 				mat.Color = hairColor;
 				mat.Effects = 0;
 			}
-			mat.Set("u_silhouette_color", hairColor);
+            mat.SilhouetteColor = hairColor;
 		}
 
         hair = new()

--- a/Source/Actors/Player.cs
+++ b/Source/Actors/Player.cs
@@ -629,7 +629,7 @@ public class Player : Actor, IHaveModels, IHaveSprites, IRidePlatforms, ICastPoi
 				mat.Color = color;
 				mat.Effects = 0;
 			}
-			mat.Set("u_silhouette_color", color);
+            mat.SilhouetteColor = color;
 		}
 
 		Hair.Color = color;

--- a/Source/Graphics/Hair.cs
+++ b/Source/Graphics/Hair.cs
@@ -154,7 +154,7 @@ public class Hair : Model
 		state.ModelMatrix = was;
 
 		Materials[0].Color = Color;
-		Materials[0].Set("u_silhouette_color", Color);
+		Materials[0].SilhouetteColor = Color;
 
 		// draw hair
 		var call = new DrawCommand(state.Camera.Target, mesh, Materials[0])

--- a/Source/Graphics/Materials.cs
+++ b/Source/Graphics/Materials.cs
@@ -25,7 +25,11 @@ public class DefaultMaterial : Material
     public DefaultMaterial(Texture? texture = null)
 		: base(Assets.Shaders["Default"])
 	{
-		Debug.Assert(Shader != null && Shader.Has(MatrixUniformName), $"Shader '{Shader.Name}' is missing '{MatrixUniformName}' uniform");
+        if (!(Shader?.Has(MatrixUniformName) ?? false))
+        {
+            Log.Warning($"Shader '{Shader?.Name}' is missing '{MatrixUniformName}' uniform");
+        }
+        
         Texture = texture;
 		Color = Color.White;
 		Effects = 1.0f;
@@ -34,13 +38,23 @@ public class DefaultMaterial : Material
     public Matrix MVP
     {
         get => matrix;
-        set => Set(MatrixUniformName, matrix = value);
+        set
+        {
+            matrix = value;
+            if (Shader?.Has(MatrixUniformName) ?? false)
+                Set(MatrixUniformName, value);
+        }
     }
 
     public Matrix Model
     {
         get => model;
-        set => Set("u_model", model = value);
+        set
+        {
+            model = value;
+            if (Shader?.Has("u_model") ?? false)
+                Set("u_model", value);
+        }
     }
 
     public Texture? Texture

--- a/Source/Graphics/Skybox.cs
+++ b/Source/Graphics/Skybox.cs
@@ -60,10 +60,14 @@ public class Skybox
 	public void Render(in Camera camera, in Matrix transform, float size)
 	{
 		var mat = Matrix.CreateScale(size) * transform * camera.ViewProjection;
-		material.Set("u_matrix", mat);
-		material.Set("u_near", camera.NearPlane);
-		material.Set("u_far", camera.FarPlane);
-		material.Set("u_texture", Texture);
+        if (material.Shader?.Has("u_matrix") ?? false)
+		    material.Set("u_matrix", mat);
+        if (material.Shader?.Has("u_near") ?? false)
+		    material.Set("u_near", camera.NearPlane);
+        if (material.Shader?.Has("u_far") ?? false)
+		    material.Set("u_far", camera.FarPlane);
+        if (material.Shader?.Has("u_texture") ?? false)
+		    material.Set("u_texture", Texture);
 
 		DrawCommand cmd = new(camera.Target, mesh, material)
 		{

--- a/Source/Graphics/SpriteRenderer.cs
+++ b/Source/Graphics/SpriteRenderer.cs
@@ -58,13 +58,17 @@ public class SpriteRenderer
 
 		spriteMesh.SetVertices<SpriteVertex>(CollectionsMarshal.AsSpan(spriteVertices));
 		spriteMesh.SetIndices<int>(CollectionsMarshal.AsSpan(spriteIndices));
-		spriteMaterial.Set("u_matrix", state.Camera.ViewProjection);
-		spriteMaterial.Set("u_far", state.Camera.FarPlane);
-		spriteMaterial.Set("u_near", state.Camera.NearPlane);
+        if (spriteMaterial.Shader?.Has("u_matrix") ?? false)
+		    spriteMaterial.Set("u_matrix", state.Camera.ViewProjection);
+        if (spriteMaterial.Shader?.Has("u_far") ?? false)
+		    spriteMaterial.Set("u_far", state.Camera.FarPlane);
+        if (spriteMaterial.Shader?.Has("u_near") ?? false)
+		    spriteMaterial.Set("u_near", state.Camera.NearPlane);
 
 		foreach (var batch in spriteBatches)
 		{
-			spriteMaterial.Set("u_texture", batch.Texture);
+            if (spriteMaterial.Shader?.Has("u_texture") ?? false)
+			    spriteMaterial.Set("u_texture", batch.Texture);
 
 			var call = new DrawCommand(state.Camera.Target, spriteMesh, spriteMaterial)
 			{

--- a/Source/Scenes/Overworld.cs
+++ b/Source/Scenes/Overworld.cs
@@ -328,11 +328,16 @@ public class Overworld : Scene
 				Matrix.CreateRotationZ((state == States.Entering ? -1 : 1) * rotation * MathF.PI) *
 				Matrix.CreateTranslation(position);
 
-			material.Set("u_matrix", matrix * camera.ViewProjection);
-			material.Set("u_near", camera.NearPlane);
-			material.Set("u_far", camera.FarPlane);
-			material.Set("u_texture", it.Target);
-			material.Set("u_texture_sampler", new TextureSampler(TextureFilter.Linear, TextureWrap.ClampToEdge, TextureWrap.ClampToEdge));
+            if (material.Shader?.Has("u_matrix") ?? false)
+			    material.Set("u_matrix", matrix * camera.ViewProjection);
+            if (material.Shader?.Has("u_near") ?? false)
+			    material.Set("u_near", camera.NearPlane);
+            if (material.Shader?.Has("u_far") ?? false)
+			    material.Set("u_far", camera.FarPlane);
+            if (material.Shader?.Has("u_texture") ?? false)
+			    material.Set("u_texture", it.Target);
+            if (material.Shader?.Has("u_texture_sampler") ?? false)
+			    material.Set("u_texture_sampler", new TextureSampler(TextureFilter.Linear, TextureWrap.ClampToEdge, TextureWrap.ClampToEdge));
 
 			var cmd = new DrawCommand(target, mesh, material)
 			{

--- a/Source/Scenes/World.cs
+++ b/Source/Scenes/World.cs
@@ -830,9 +830,12 @@ public class World : Scene
 
 			// apply post fx
 			postMaterial.SetShader(Assets.Shaders["Edge"]);
-			postMaterial.Set("u_depth", Camera.Target.Attachments[1]);
-			postMaterial.Set("u_pixel", new Vec2(1.0f / postCam.Target.Width, 1.0f / postCam.Target.Height));
-			postMaterial.Set("u_edge", new Color(0x110d33));
+            if (postMaterial.Shader?.Has("u_depth") ?? false)
+			    postMaterial.Set("u_depth", Camera.Target.Attachments[1]);
+            if (postMaterial.Shader?.Has("u_pixel") ?? false)
+			    postMaterial.Set("u_pixel", new Vec2(1.0f / postCam.Target.Width, 1.0f / postCam.Target.Height));
+            if (postMaterial.Shader?.Has("u_edge") ?? false)
+			    postMaterial.Set("u_edge", new Color(0x110d33));
 			batch.PushMaterial(postMaterial);
 			batch.Image(Camera.Target.Attachments[0], Color.White);
 			batch.Render(postTarget);


### PR DESCRIPTION
Some GPUs will optimize the shader pipeline in such a way, that unused uniforms will get stripped from the shader. That means that even a simple shader-edit can cause issues.

For example, adding this line at the end of `Default.glsl`'s fragment shader:
```glsl
o_color = vec4(1.0);
```
Might cause a crash on startup, since the `u_model` uniform got optimized away.

This PR adds checks to every uniform-set call, to make it easier for someone to edit the shaders.