### PR TITLE
Change anti-spike-climb-hop check to a threshold of 4 units

### DIFF
--- a/Source/Actors/Player.cs
+++ b/Source/Actors/Player.cs
@@ -1489,7 +1489,7 @@ public class Player : Actor, IHaveModels, IHaveSprites, IRidePlatforms, ICastPoi
 
 			// don't climb over ledges into spikes
 			// (you can still climb up into spikes if they're on the same wall as you)
-			if (move.Z > 0 && World.Overlaps<SpikeBlock>(Position + Vec3.UnitZ * 6 + forward * (ClimbCheckDist + 1)))
+			if (move.Z > 0 && World.Overlaps<SpikeBlock>(Position + Vec3.UnitZ * ClimbCheckDist + forward * (ClimbCheckDist + 1)))
 				move.Z = 0;
 
 			// don't move left/right around into a spikes


### PR DESCRIPTION
This re-enables a skip used in speedrunning - it could be that I'm unskilled, but I couldn't reproduce it post- f4fed81c3566ea670cdbae3d58196473bea24c6f, but could with this patch. See https://youtu.be/PEi3ySaSivo?t=16 (0:16.5).