### PR TITLE
forget selected index in pause menu

### DIFF
--- a/Source/Scenes/World.cs
+++ b/Source/Scenes/World.cs
@@ -370,7 +370,6 @@ public class World : Scene
 		{
 			if (Controls.Pause.Pressed || Controls.Cancel.Pressed)
 			{
-				pauseMenu.Index = 0;
 				SetPaused(false);
 				Audio.Play(Sfx.ui_unpause);
 			}
@@ -393,8 +392,10 @@ public class World : Scene
 				Audio.Play(Sfx.ui_pause);
 				pauseSnapshot = Audio.Play(Sfx.snapshot_pause);
 			}
-			else
+			else {
+				pauseMenu.Index = 0;
 				pauseSnapshot.Stop();
+			}
 
 			Controls.Consume();
 			Paused = paused;

--- a/Source/Scenes/World.cs
+++ b/Source/Scenes/World.cs
@@ -370,6 +370,7 @@ public class World : Scene
 		{
 			if (Controls.Pause.Pressed || Controls.Cancel.Pressed)
 			{
+				pauseMenu.Index = 0;
 				SetPaused(false);
 				Audio.Play(Sfx.ui_unpause);
 			}


### PR DESCRIPTION
resets the index of selected item in pause menu to 0 upon unpause. Makes pause -> retry more consistent