### PR TITLE
Add functionality to center camera on player back

### DIFF
--- a/Source/Actors/Player.cs
+++ b/Source/Actors/Player.cs
@@ -268,11 +268,20 @@ public class Player : Actor, IHaveModels, IHaveSprites, IRidePlatforms, ICastPoi
 		{
 			// Rotate Camera
 			{
-				var rot = new Vec2(cameraTargetForward.X, cameraTargetForward.Y).Angle();
-				rot -= Controls.Camera.Value.X * Time.Delta * 4;
+				if (!Controls.BackCamera.Pressed)
+				{
+					var rot = new Vec2(cameraTargetForward.X, cameraTargetForward.Y).Angle();
+					rot -= Controls.Camera.Value.X * Time.Delta * 4;
 
-				var angle = Calc.AngleToVector(rot);
-				cameraTargetForward = new(angle, 0);
+					var angle = Calc.AngleToVector(rot);
+					cameraTargetForward = new(angle, 0);
+				}
+				else
+				{
+					var rot = Facing.Angle();
+					var angle = Calc.AngleToVector(rot);
+					cameraTargetForward = new(angle, 0);
+				}
 			}
 
 			// Move Camera in / out

--- a/Source/Controls.cs
+++ b/Source/Controls.cs
@@ -9,8 +9,9 @@ public static class Controls
 	public static readonly VirtualButton Jump = new("Jump", .1f);
 	public static readonly VirtualButton Dash = new("Dash", .1f);
 	public static readonly VirtualButton Climb = new("Climb");
+	public static readonly VirtualButton BackCamera = new("BackCamera");
 
-	public static readonly VirtualButton Confirm = new("Confirm");
+    public static readonly VirtualButton Confirm = new("Confirm");
 	public static readonly VirtualButton Cancel = new("Cancel");
 	public static readonly VirtualButton Pause = new("Pause");
 
@@ -25,6 +26,10 @@ public static class Controls
 		Camera.AddRightJoystick(0, 0.50f, 0.70f);
 		Camera.Add(Keys.A, Keys.D, Keys.W, Keys.S);
 
+		BackCamera.Clear();
+		BackCamera.Add(0, Axes.LeftTrigger, 1, .4f);
+		BackCamera.Add(Keys.E);
+
 		Jump.Clear();
 		Jump.Add(0, Buttons.A, Buttons.Y);
 		Jump.Add(Keys.C);
@@ -36,7 +41,6 @@ public static class Controls
 		Climb.Clear();
 		Climb.Add(0, Buttons.LeftShoulder, Buttons.RightShoulder);
 		Climb.Add(0, Axes.RightTrigger, 1, .4f);
-		Climb.Add(0, Axes.LeftTrigger, 1, .4f);
 		Climb.Add(Keys.Z, Keys.V, Keys.LeftShift, Keys.RightShift);
 		
 		Menu.Clear();
@@ -62,6 +66,7 @@ public static class Controls
 		Move.Consume();
 		Menu.Consume();
 		Camera.Consume();
+		BackCamera.Consume();
 		Jump.Consume();
 		Dash.Consume();
 		Climb.Consume();


### PR DESCRIPTION
Since sometimes I want to see what's exactly in front of me, instead of manually rotating the camera to be behind the player, I think it would be nice to have the functionality to focus the camera on the back of the player.

I implemented this by reassigning the left trigger and the E key to do this, but if there are better buttons to do so, that would be OK too 🙂