### PR TITLE
Change "Windowx" back to "Windows"

### DIFF
--- a/Celeste64.csproj
+++ b/Celeste64.csproj
@@ -23,7 +23,7 @@
     <IsLinux>true</IsLinux>
   </PropertyGroup>
 
-  <PropertyGroup Condition="($(RuntimeIdentifier) == '' and $([MSBuild]::IsOSPlatform('Windowx'))) or $(RuntimeIdentifier.StartsWith('win'))">
+  <PropertyGroup Condition="($(RuntimeIdentifier) == '' and $([MSBuild]::IsOSPlatform('Windows'))) or $(RuntimeIdentifier.StartsWith('win'))">
     <IsWindows>true</IsWindows>
   </PropertyGroup>
 


### PR DESCRIPTION
In the latest FMOD commit `Windows` was changed to `Windowx` which causes the game to immediately throw an error when trying to build and run. Changing the line back to `Windows` fixed the issue.