### PR TITLE
Add option to invert camera controls with MultiSelect

### DIFF
--- a/Content/Text/English.json
+++ b/Content/Text/English.json
@@ -22,7 +22,8 @@
 		"OptionsZGuide": "Z-Guide",
 		"OptionsTimer": "Timer",
 		"OptionsBGM": "BGM",
-		"OptionsSFX": "SFX"
+		"OptionsSFX": "SFX",
+		"OptionsInvertCamera": "Inverted Camera"
 	},
 	"Dialog":
 	{

--- a/Source/Actors/Player.cs
+++ b/Source/Actors/Player.cs
@@ -269,7 +269,7 @@ public class Player : Actor, IHaveModels, IHaveSprites, IRidePlatforms, ICastPoi
 			// Rotate Camera
 			{
 				var rot = new Vec2(cameraTargetForward.X, cameraTargetForward.Y).Angle();
-				rot -= Controls.Camera.Value.X * Time.Delta * 4;
+				rot -= Controls.Camera.Value.X * Time.Delta * 4 * (Save.Instance.InvertCamera == "X" || Save.Instance.InvertCamera == "Both" ? -1 : 1);
 
 				var angle = Calc.AngleToVector(rot);
 				cameraTargetForward = new(angle, 0);
@@ -278,7 +278,7 @@ public class Player : Actor, IHaveModels, IHaveSprites, IRidePlatforms, ICastPoi
 			// Move Camera in / out
 			if (Controls.Camera.Value.Y != 0)
 			{
-				cameraTargetDistance += Controls.Camera.Value.Y * Time.Delta;
+				cameraTargetDistance += Controls.Camera.Value.Y * Time.Delta * (Save.Instance.InvertCamera == "Y" || Save.Instance.InvertCamera == "Both" ? -1 : 1);
 				cameraTargetDistance = Calc.Clamp(cameraTargetDistance, 0, 1);
 			}
 			else

--- a/Source/Data/Save.cs
+++ b/Source/Data/Save.cs
@@ -69,6 +69,11 @@ public class Save
 	public int SfxVolume { get; set; } = 10;
 
 	/// <summary>
+	/// Invert the camera in given directions
+	/// </summary>
+	public string InvertCamera { get; set; } = "None";
+
+	/// <summary>
 	/// Current Language ID
 	/// </summary>
 	public string Language = "english";
@@ -126,6 +131,11 @@ public class Save
 	public void ToggleZGuide()
 	{
 		ZGuide = !ZGuide;
+	}
+
+	public void SetCameraInverted(string value)
+	{
+		InvertCamera = value;
 	}
 
 	public void ToggleTimer()

--- a/Source/Helpers/Menu.cs
+++ b/Source/Helpers/Menu.cs
@@ -94,6 +94,26 @@ public class Menu
 		}
 	}
 
+	public class MultiSelect(string label, List<string> options, Action<string> set) : Item
+	{
+		private readonly List<string> options = options;
+		private readonly Action<string> set = set;
+		private int index = 0;
+		public override string Label => $"{label} : {options[index]}";
+
+		public override void Slide(int dir) 
+		{
+			Audio.Play(Sfx.ui_select);
+
+			if (index != options.Count() - 1 && dir == 1)
+				index++;
+			if (index != 0 && dir == -1)
+				index--;
+
+			set(Label);
+		}
+	}
+
 	public int Index;
 	public string Title = string.Empty;
 	public bool Focused = true;

--- a/Source/Helpers/Menu.cs
+++ b/Source/Helpers/Menu.cs
@@ -110,7 +110,7 @@ public class Menu
 			if (index != 0 && dir == -1)
 				index--;
 
-			set(Label);
+			set(options[index]);
 		}
 	}
 

--- a/Source/Scenes/World.cs
+++ b/Source/Scenes/World.cs
@@ -82,10 +82,10 @@ public class World : Scene
 			optionsMenu.Add(new Menu.Toggle(Loc.Str("OptionsFullscreen"), Save.Instance.ToggleFullscreen, () => Save.Instance.Fullscreen));
 			optionsMenu.Add(new Menu.Toggle(Loc.Str("OptionsZGuide"), Save.Instance.ToggleZGuide, () => Save.Instance.ZGuide));
 			optionsMenu.Add(new Menu.Toggle(Loc.Str("OptionsTimer"), Save.Instance.ToggleTimer, () => Save.Instance.SpeedrunTimer));
+			optionsMenu.Add(new Menu.MultiSelect(Loc.Str("OptionsInvertCamera"), new List<string> { "None", "X", "Y", "Both" }, Save.Instance.SetCameraInverted));
 			optionsMenu.Add(new Menu.Spacer());
 			optionsMenu.Add(new Menu.Slider(Loc.Str("OptionsBGM"), 0, 10, () => Save.Instance.MusicVolume, Save.Instance.SetMusicVolume));
 			optionsMenu.Add(new Menu.Slider(Loc.Str("OptionsSFX"), 0, 10, () => Save.Instance.SfxVolume, Save.Instance.SetSfxVolume));
-			optionsMenu.Add(new Menu.MultiSelect(Loc.Str("OptionsInvertCamera"), new List<string> { "None", "X", "Y", "Both"} , Save.Instance.SetCameraInverted));
 
 			pauseMenu.Title = Loc.Str("PauseTitle");
             pauseMenu.Add(new Menu.Option(Loc.Str("PauseResume"), () => SetPaused(false)));

--- a/Source/Scenes/World.cs
+++ b/Source/Scenes/World.cs
@@ -85,6 +85,7 @@ public class World : Scene
 			optionsMenu.Add(new Menu.Spacer());
 			optionsMenu.Add(new Menu.Slider(Loc.Str("OptionsBGM"), 0, 10, () => Save.Instance.MusicVolume, Save.Instance.SetMusicVolume));
 			optionsMenu.Add(new Menu.Slider(Loc.Str("OptionsSFX"), 0, 10, () => Save.Instance.SfxVolume, Save.Instance.SetSfxVolume));
+			optionsMenu.Add(new Menu.MultiSelect(Loc.Str("OptionsInvertCamera"), new List<string> { "None", "X", "Y", "Both"} , Save.Instance.SetCameraInverted));
 
 			pauseMenu.Title = Loc.Str("PauseTitle");
             pauseMenu.Add(new Menu.Option(Loc.Str("PauseResume"), () => SetPaused(false)));


### PR DESCRIPTION
Added a MultiSelect subclass of Item to use to select between 'None', 'X', 'Y', or 'Both' inverted camera options

![1](https://github.com/ExOK/Celeste64/assets/28875679/3dcd4a35-3a10-46ae-a5b6-85dc17f22652)
![2](https://github.com/ExOK/Celeste64/assets/28875679/0f4c7152-08d9-4f30-8d4c-488209c7150e)
![3](https://github.com/ExOK/Celeste64/assets/28875679/b97e5313-f191-465b-b32d-59e7709dd19e)
