### PR TITLE
Fix unpause in submenu

### DIFF
--- a/Source/Data/ControlsConfig.cs
+++ b/Source/Data/ControlsConfig.cs
@@ -91,11 +91,13 @@ public class ControlsConfig
 		}
 	}
 
+	public double? Version { get; set; }
 	public Dictionary<string, List<Binding>> Actions { get; set; } = [];
 	public Dictionary<string, Stick> Sticks { get; set; } = [];
 
 	public static ControlsConfig Defaults = new()
 	{
+		Version = 1.1,
 		Actions = new() {
 			["Jump"] = [
 				new(Keys.C),
@@ -119,7 +121,7 @@ public class ControlsConfig
 				new(Buttons.East) { OnlyFor = Gamepads.Nintendo },
 			],
 			["Cancel"] = [
-				new(Keys.X),
+				new(Keys.X), new(Keys.Escape),
 				new(Buttons.East) { NotFor = Gamepads.Nintendo },
 				new(Buttons.South) { OnlyFor = Gamepads.Nintendo },
 			],
@@ -197,6 +199,39 @@ public class ControlsConfig
 			},
 		}
 	};
+
+	public void Update()
+    {
+        Version ??= 1.0;
+		bool updated = false;
+
+		if (Version == null)
+		{
+			updated = true;
+			Version = 1.0;
+
+		}
+
+		if (Version < 1.1)
+		{
+			updated = true;
+			Version = 1.1;
+			Actions["Cancel"].Add(new(Keys.Escape));
+		}
+
+        if (updated)
+        {
+			var controlsPath = Path.Join(App.UserPath, FileName);
+			var stream = File.Create(controlsPath);
+			Serialize(stream, this);
+			stream.Flush();
+        }
+    }
+
+	public static void Serialize(Stream stream, ControlsConfig instance)
+	{
+		JsonSerializer.Serialize(stream, instance, ControlsConfigContext.Default.ControlsConfig);
+	}
 }
 
 // All of this is just so the Binding values are on a single line to increase readability

--- a/Source/Scenes/Startup.cs
+++ b/Source/Scenes/Startup.cs
@@ -51,7 +51,7 @@ public class Startup : Scene
 				JsonSerializer.Serialize(stream, ControlsConfig.Defaults, ControlsConfigContext.Default.ControlsConfig);
 				stream.Flush();
 			}
-			
+			controls.Update();
 			Controls.Load(controls);
 		}
 

--- a/Source/Scenes/World.cs
+++ b/Source/Scenes/World.cs
@@ -372,7 +372,7 @@ public class World : Scene
 		// unpause
 		else
 		{
-			if ((Controls.Pause.Pressed || Controls.Cancel.Pressed) && pauseMenu.IsInMainMenu)
+			if ((Controls.Pause.Pressed && !Controls.Cancel.Pressed) || (Controls.Cancel.Pressed && pauseMenu.IsInMainMenu))
 			{
 				pauseMenu.CloseSubMenus();
 				SetPaused(false);


### PR DESCRIPTION
I added the ability to unpause the game while in a submenu by a pause button/key. 

I also mapped the escape key to "cancel" so that when you press escape in a submenu, it goes back instead of unpausing (same behaviour as pressing escape key in a submenu in Celeste)

I had to add a version system to ControlsConfig to map the escape key if you already have a controls.json file.
