### PR TITLE
* Player: Fix slight control issue.

### DIFF
--- a/Source/Actors/Player.cs
+++ b/Source/Actors/Player.cs
@@ -474,8 +474,9 @@ public class Player : Actor, IHaveModels, IHaveSprites, IRidePlatforms, ICastPoi
 				GetCameraTarget(out lookAt, out cameraPos, out _);
 			}
 
-			World.Camera.Position += (cameraPos - World.Camera.Position) * (1 - MathF.Pow(0.01f, Time.Delta));
-			World.Camera.LookAt = lookAt;
+            World.CameraDestPos = cameraPos;
+            World.Camera.Position += (cameraPos - World.Camera.Position) * (1 - MathF.Pow(0.01f, Time.Delta));
+            World.Camera.LookAt = lookAt;
 
 			float targetFOV = Calc.ClampedMap(velocity.XY().Length(), MaxSpeed * 1.2f, 120, 1, 1.2f);
 
@@ -602,7 +603,13 @@ public class Player : Actor, IHaveModels, IHaveSprites, IRidePlatforms, ICastPoi
 				return Vec2.Zero;
 
 			Vec2 forward, side;
-			var cameraForward = World.Camera.Forward.XY();
+
+            // HACK:  Calculate camera forward vector based on World.CameraDestPos
+			// instead of World.Camera.Position.  This allows the player to keep going
+			// in the same direction (not slightly shifted left/right), even though
+			// the camera always tries to be "ahead" of the player.
+            var cameraForward = (World.Camera.LookAt - World.CameraDestPos).Normalized().XY();
+
 			if (cameraForward.X == 0 && cameraForward.Y == 0)
 				forward = targetFacing;
 			else

--- a/Source/Scenes/World.cs
+++ b/Source/Scenes/World.cs
@@ -43,6 +43,9 @@ public class World : Scene
 	private float strawbCounterEase = 0;
 	private int strawbCounterWas;
 
+	// the position that the camera follows
+	public Vector3 CameraDestPos;
+
 	private bool IsInEndingArea => Get<Player>() is {} player && Overlaps<EndingArea>(player.Position);
 	private bool IsPauseEnabled
 	{


### PR DESCRIPTION
Essentially, the player will take a detour towards the camera when moving left/right.

The fix is simple - keep a different "camera target position" and use that in the "forward" calculation, rather than World.Camera.Forward.

Ideally the camera itself would have a "destination" field, but this is fine for now.
