### PR TITLE
Fix restart flipping all cards when pressing restart

### DIFF
--- a/Source/Scenes/Overworld.cs
+++ b/Source/Scenes/Overworld.cs
@@ -187,7 +187,7 @@ public class Overworld : Scene
 		{
 			var it = entries[i];
 			Calc.Approach(ref it.HighlightEase, index == i ? 1.0f : 0.0f, Time.Delta * 8.0f); 
-			Calc.Approach(ref it.SelectionEase, index == i && state == States.Selected || state == States.Restarting ? 1.0f : 0.0f, Time.Delta * 4.0f);
+			Calc.Approach(ref it.SelectionEase, index == i && (state == States.Selected || state == States.Restarting) ? 1.0f : 0.0f, Time.Delta * 4.0f);
 
 			if (it.SelectionEase >= 0.50f && state == States.Selected)
 				it.Menu.Update();


### PR DESCRIPTION
Small fix that prevents all cards in the level select screens from flipping over when you press restart on a level if there are multiple levels.