### PR TITLE
Fixing Localization Issues where Language was not being loaded correctly from the save file.

### DIFF
--- a/Source/Data/Save.cs
+++ b/Source/Data/Save.cs
@@ -84,7 +84,7 @@ public class Save
 	/// <summary>
 	/// Current Language ID
 	/// </summary>
-	public string Language = "english";
+	public string Language { get; set; } = "english";
 
 	/// <summary>
 	/// Records for each level

--- a/Source/Scenes/Startup.cs
+++ b/Source/Scenes/Startup.cs
@@ -26,6 +26,10 @@ public class Startup : Scene
 			Save.Instance.SyncSettings();
 		}
 
+		// make sure the active language is ready for use,
+		// since the save file may have loaded a different language than default.
+		Language.Current.Use();
+
 		// try to load controls, or overwrite with defaults if they don't exist
 		{
 			var controlsFile = Path.Join(App.UserPath, ControlsConfig.FileName);


### PR DESCRIPTION
I noticed and fixed two issues with the localization setup, which was making it so no language other than the default could be used. First it seemed that the Languages wasn't getting properly loaded from the save file. I believe this was because it was just a variable, not a property. Changing it to a property fixed it for me.
Second, I saw it was throwing an error if it did try to load a save file with the language other than English, because Language.Current.Use gets called before the save file is loaded during Assets.Load, so it just uses the default. It needs to get called after the save file is loaded instead of as well, to get around this error.

To test this, create a copy of English.json, and call it Spanish.json. Change the ID and Label in the file to Spanish, and change some of the strings to be different from the default English strings. Confirm and Back are easiest, since you can see them from the title screen.
Next, go to the Save.json save file, and manually add   "Language": "spanish", to the save file.
If you did this before my changes, it would still load the strings and dialog from the default English, but after my changes, it should load correctly from the language specified in the save.json file.