### PR TITLE
Fix White Hair in Cutscenes

### DIFF
--- a/Source/Actors/Player.cs
+++ b/Source/Actors/Player.cs
@@ -1998,6 +1998,12 @@ public class Player : Actor, IHaveModels, IHaveSprites, IRidePlatforms, ICastPoi
 	private void StCutsceneEnter()
 	{
 		Model.Play("Idle");
+		// Fix white hair in cutscene bug
+		if (tDashResetFlash > 0)
+		{
+			tDashResetFlash = 0;
+			SetHairColor(CNormal);
+		}
 	}
 
 	private void StCutsceneUpdate()


### PR DESCRIPTION
If you dash in the air and land as you start a cutscene/dialogue Madeline's hair will stay white throughout the duration of the cutscene. By checking if the "flash" is currently happening when the dialogue starts we can catch it and reset the hair back to normal. Example of this glitch is attached:

![image](https://github.com/ExOK/Celeste64/assets/38361803/8ae3d813-7662-4cb4-9bf9-6ed8fb16b220)