### PR TITLE
Turn camera by 45° steps

### DIFF
--- a/Source/Actors/Player.cs
+++ b/Source/Actors/Player.cs
@@ -269,8 +269,19 @@ public class Player : Actor, IHaveModels, IHaveSprites, IRidePlatforms, ICastPoi
 			// Rotate Camera
 			{
 				var invertX = Save.Instance.InvertCamera == Save.InvertCameraOptions.X || Save.Instance.InvertCamera == Save.InvertCameraOptions.Both;
+				var invertX_val = invertX ? -1 : 1;
 				var rot = new Vec2(cameraTargetForward.X, cameraTargetForward.Y).Angle();
-				rot -= Controls.Camera.Value.X * Time.Delta * 4 * (invertX ? -1 : 1);
+				rot -= Controls.Camera.Value.X * Time.Delta * 4 * invertX_val;
+
+				// Rotate camera by 45° steps
+				if (Controls.CameraLeftStep.Pressed)
+				{
+					rot = (MathF.Round(rot * 4 / MathF.PI) + invertX_val) * MathF.PI * 0.25f;
+				}
+				if (Controls.CameraRightStep.Pressed)
+				{
+					rot = (MathF.Round(rot * 4 / MathF.PI) - invertX_val) * MathF.PI * 0.25f;
+				}
 
 				var angle = Calc.AngleToVector(rot);
 				cameraTargetForward = new(angle, 0);

--- a/Source/Data/Controls.cs
+++ b/Source/Data/Controls.cs
@@ -12,6 +12,8 @@ public static class Controls
 	public static readonly VirtualButton Confirm = new("Confirm");
 	public static readonly VirtualButton Cancel = new("Cancel");
 	public static readonly VirtualButton Pause = new("Pause");
+	public static readonly VirtualButton CameraLeftStep = new("CameraLeftStep");
+	public static readonly VirtualButton CameraRightStep = new("CameraRightStep");
 
 	public static void Load(ControlsConfig? config = null)
 	{
@@ -51,13 +53,18 @@ public static class Controls
 			it.BindTo(Cancel);
 		foreach (var it in FindAction(config, "Pause"))
 			it.BindTo(Pause);
-
+		foreach (var it in FindAction(config, "CameraLeftStep"))
+			it.BindTo(CameraLeftStep);
+		foreach (var it in FindAction(config, "CameraRightStep"))
+			it.BindTo(CameraRightStep);
 	}
 
 	public static void Clear()
 	{
 		Move.Clear();
 		Camera.Clear();
+		CameraLeftStep.Clear();
+		CameraRightStep.Clear();
 		Jump.Clear();
 		Dash.Clear();
 		Climb.Clear();
@@ -72,6 +79,8 @@ public static class Controls
 		Move.Consume();
 		Menu.Consume();
 		Camera.Consume();
+		CameraLeftStep.Consume();
+		CameraRightStep.Consume();
 		Jump.Consume();
 		Dash.Consume();
 		Climb.Consume();

--- a/Source/Data/ControlsConfig.cs
+++ b/Source/Data/ControlsConfig.cs
@@ -109,9 +109,14 @@ public class ControlsConfig
 			],
 			["Climb"] = [
 				new(Keys.Z),new(Keys.V),new(Keys.LeftShift),new(Keys.RightShift),
-				new(Buttons.LeftShoulder),new(Buttons.RightShoulder),
 				new(Axes.LeftTrigger, 0.4f, false),
 				new(Axes.RightTrigger, 0.4f, false),
+			],
+			["CameraLeftStep"] = [
+				new(Buttons.LeftShoulder),
+			],
+			["CameraRightStep"] = [
+				new(Buttons.RightShoulder),
 			],
 			["Confirm"] = [
 				new(Keys.C),


### PR DESCRIPTION
Adds a Mario 64 esque feature to turn camera by steps of 45° using the shoulder buttons.
It also makes sure that the camera is always at angles of 0°, 45°, 90°... when pressing the shoulder buttons.
I mostly did this for myself, as I wanted an easier way to turn my camera at more straight angles, but felt like other people could enjoy it too so doing a PR request :p

probably conflicts with #48 