### PR TITLE
Yellow orbs when dying in feather

### DIFF
--- a/Source/Actors/Player.cs
+++ b/Source/Actors/Player.cs
@@ -493,7 +493,7 @@ public class Player : Actor, IHaveModels, IHaveSprites, IRidePlatforms, ICastPoi
 			Model.Update();
 			Model.Transform = Matrix.CreateScale(ModelScale * 3);
 
-			if (stateMachine.State != States.Feather && stateMachine.State != States.FeatherStart)
+			if (!Dead && stateMachine.State != States.Feather && stateMachine.State != States.FeatherStart)
 			{
 				Color color;
 				if (tDashResetFlash > 0)


### PR DESCRIPTION
Makes it so that hair color doesn't get changed during the death animation, which would allow the color to stay as yellow if you die in a feather (rather than the number of dashes you have).